### PR TITLE
buildpack:set instead of config:set when updating existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git push heroku master
 When modifying an existing Heroku app:
 
 ```bash
-heroku config:set BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
+heroku buildpack:set https://github.com/ddollar/heroku-buildpack-multi.git
 
 cat << EOF > .buildpacks
 https://github.com/mojodna/heroku-buildpack-cairo.git


### PR DESCRIPTION
BUILDPACK_URL as a config var is now deprecated, and is giving me problems on cedar-14.  The docs should be updated here to tell users to use the buildpack:set directive.

Ref https://devcenter.heroku.com/articles/buildpacks#using-a-custom-buildpack