### PR TITLE
Update binary versions

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,24 +42,13 @@ function vendor() {
 }
 
 echo "-----> Vendoring binaries"
-vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/cairo-1.14.2-1.tar.gz"  "$BUILD_DIR/vendor/cairo"
-vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/freetype-2.5.5-1.tar.gz" "$BUILD_DIR/vendor/freetype"
-vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/giflib-4.2.3-2.tar.gz"   "$BUILD_DIR/vendor/giflib"
-vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/pixman-0.32.6-2.tar.gz"  "$BUILD_DIR/vendor/pixman"
-
-if [ $STACK == "cedar-14" ]; then
-  vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/pango-1.36.8-1.tar.gz"  "$BUILD_DIR/vendor/pango"
-  vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/harfbuzz-0.9.39-1.tar.gz"  "$BUILD_DIR/vendor/harfbuzz"
-  vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/fontconfig-2.11.93-1.tar.gz"  "$BUILD_DIR/vendor/fontconfig"
-else
-  echo
-  echo "-----> WARNING <-----"
-  echo
-  echo "You are using the cedar-10 stack--node-canvas 1.2.1 cannot build due to" | indent
-  echo "missing dependencies. Please consider updating to the cedar-14 stack:" | indent
-  echo "heroku stack:set cedar-14" | indent
-  echo
-fi
+vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/cairo-1.14.6-1.tar.gz"  "$BUILD_DIR/vendor/cairo"
+vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/freetype-2.6.5-1.tar.gz" "$BUILD_DIR/vendor/freetype"
+vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/giflib-4.2.3-3.tar.gz"   "$BUILD_DIR/vendor/giflib"
+vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/pixman-0.34.0-1.tar.gz"  "$BUILD_DIR/vendor/pixman"
+vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/pango-1.40.1-1.tar.gz"  "$BUILD_DIR/vendor/pango"
+vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/harfbuzz-1.3.0-1.tar.gz"  "$BUILD_DIR/vendor/harfbuzz"
+vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/fontconfig-2.12.1-1.tar.gz"  "$BUILD_DIR/vendor/fontconfig"
 
 echo "-----> Tweaking Cairo, FreeType, and Pixman include paths"
 


### PR DESCRIPTION
cairo → 1.14.6 (1.14.2)
freetype → 2.6.5 (2.5.5)
pixman → 0.34.0 (0.32.6)
pango → 1.40.1 (1.36.8)
harfbuzz → 1.3.0 (0.9.39)
fontconfig → 2.12.1 (2.11.93)
